### PR TITLE
.github/workflows: use go.mod to get the go version

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493  # v5.0.0
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
         with:
-          go-version: "1.23.x"
+          go-version-file: "go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8.0.0
         with:

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -26,6 +26,7 @@ jobs:
         pipelines-release:
         # This should follow the list of versions from https://github.com/tektoncd/pipeline/blob/main/releases.md#release
         - v1.0.0
+        - v1.3.0
     uses: ./.github/workflows/reusable-e2e.yaml
     with:
       k8s-version: v1.29.x

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: 1.22.x
+        go-version-file: "go.mod"
 
     - uses: ko-build/setup-ko@v0.9
       with:

--- a/.github/workflows/reusable-e2e.yaml
+++ b/.github/workflows/reusable-e2e.yaml
@@ -21,8 +21,6 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      GOPATH: ${{ github.workspace }}
-      GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KO_DOCKER_REPO: kind.local
       KOCACHE: ~/ko
@@ -31,6 +29,9 @@ jobs:
       # the places this is used.
 
     steps:
+    - name: Check out our repo
+      uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.1.7
+
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
@@ -40,13 +41,7 @@ jobs:
       with:
         version: tip
 
-    - name: Check out our repo
-      uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.1.7
-      with:
-        path: ./src/github.com/openshift-pipelines/tekton-assist
-
     - name: Create kind cluster
-      working-directory: ./src/github.com/openshift-pipelines/tekton-assist
       run: |  
         kind create cluster --config "./test/kind-cluster.yaml" --wait=60s
         while ! kubectl get nodes 
@@ -56,7 +51,6 @@ jobs:
         done
 
     - name: Install Tekton pipelines
-      working-directory: ./src/github.com/openshift-pipelines/tekton-assist
       run: |
         while ! kubectl apply --filename ${{ env.TEKTON_PIPELINES_RELEASE }}
         do
@@ -68,7 +62,6 @@ jobs:
         kubectl -n tekton-pipelines delete po -l app=tekton-pipelines-controller
 
     - name: Install everything
-      working-directory: ./src/github.com/openshift-pipelines/tekton-assist
       timeout-minutes: 10
       run: |
         export KO_DOCKER_REPO=kind.local
@@ -76,7 +69,6 @@ jobs:
         sleep 10
 
     - name: Run Integration tests
-      working-directory: ./src/github.com/openshift-pipelines/tekton-assist
       run: |
         echo "Running Go e2e tests"
         set +e


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This remove the error of mismatch go versions, and doesn't require us to update the CI definitions if we update go in go.mod.

cc @jkhelil @divyansh42 

Question: there is not setup-go in the release workflow ?

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
